### PR TITLE
Option to stop sweet alert closing on confirm

### DIFF
--- a/swalExtend.js
+++ b/swalExtend.js
@@ -78,7 +78,13 @@
             }
 
             if(params.clickFunctionList[i]){
-              div.addEventListener("click", params.clickFunctionList[i]);
+              div.addEventListener("click", function(x) {
+                var input = "";
+                if (typeof params.type != "undefined" && params.type == "input") {
+                  input = document.querySelector(".sweet-alert > fieldset > input").value;
+                }
+                params.clickFunctionList[x](input);
+              }.bind(null, i));
               div.addEventListener("click", function(){
                 if (typeof params.closeOnConfirm == "undefined" || params.closeOnConfirm) {
                   sweetAlert.close();

--- a/swalExtend.js
+++ b/swalExtend.js
@@ -80,7 +80,9 @@
             if(params.clickFunctionList[i]){
               div.addEventListener("click", params.clickFunctionList[i]);
               div.addEventListener("click", function(){
-                sweetAlert.close();
+                if (typeof params.closeOnConfirm == "undefined" || params.closeOnConfirm) {
+                  sweetAlert.close();
+                }
                 $(".swalExtendButton").hide();
               })
             }


### PR DESCRIPTION
The current behaviour closes the pop up if you want to provide a sweet alert embedded in a sweet alert, this change allows you to use another sweet alert on confirm.

use by including "closeOnConfirm: false" in the init of the extension.